### PR TITLE
Pausing replication with RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ within S3.
 Role Variables
 --------------
 
-Available variables are listed below, along with default values (see 
+Available variables are listed below, along with default values (see
 `defaults/main.yml`):
 
     mysql_backup_name: "mysql-s3-backup"
-    
+
 Name used to identify this role, used for default directory, file and aws profile naming.
 
     mysql_backup_dir: "/opt/{{ mysql_backup_name }}"
@@ -66,15 +66,15 @@ For separation we create a new AWS profile for this script context, you
 could set this to `"default"` to ignore profiles.
 
     mysql_backup_aws_access_key: "[accesss-key]"
-    
+
 Your Amazon AWS access key.
 
     mysql_backup_aws_secret_key: "[secret-key]"
-    
+
 Your Amazon AWS secret key.
 
     mysql_backup_aws_region: eu-west-1
-    
+
 Region name where the S3 bucket is located.
 
     mysql_backup_aws_format: text
@@ -113,6 +113,8 @@ Customisations to the backup script itself (values use bash syntax).
   Set the AWS profile to use (~/.aws/credentials and ~/.aws/config).
 * `mysql_slave: "false"`
   Set to true if backing up from a MySQL slave server, this will stop the slave and start it again when the script is finished.
+* `mysql_use_rds: "false"`
+    Set to true if backing up from an RDS read replica, this will ensure we use mysql.rds_stop_replication and mysql.rds_start_replication functions instead of the standard STOP / START SLAVE commands (which don't have the necessary permissions on RDS).
 * `mysql_use_defaults_file: "true"`
   Use default MySQL config file.
 * `mysql_defaults_file: ""`

--- a/files/backup.sh
+++ b/files/backup.sh
@@ -109,7 +109,7 @@ function cleanup {
      printf "Restart slave ... "
      if [ "$mysql_slave_restart" == "true" ]; then
        if [ "$mysql_using_rds" == true ]; then
-         "$mysql_cmd" ${mysql_args} -e "CALL mysql.rds_start_replication;"
+         "$mysql_cmd" ${mysql_args} -e "CALL mysql.rds_start_replication;" >/dev/null
        else
          "$mysqladmin_cmd" ${mysql_args} start-slave >/dev/null
        fi
@@ -262,7 +262,7 @@ if [ "$mysql_slave" == "true" ]; then
   printf "Stop slave ... "
   if [ "Yes" == "$slave_io" ] || [ "Yes" == "$slave_sql" ]; then
     if [ "$mysql_using_rds" == true ]; then
-      "$mysql_cmd" ${mysql_args} -e "CALL mysql.rds_stop_replication;"
+      "$mysql_cmd" ${mysql_args} -e "CALL mysql.rds_stop_replication;" >/dev/null
     else
       "$mysqladmin_cmd" ${mysql_args} stop-slave >/dev/null
     fi

--- a/files/backup.sh
+++ b/files/backup.sh
@@ -25,6 +25,9 @@ mysql_cmd=$(which mysql)
 # Set to true if backing up from a MySQL slave server, this will stop the slave
 # and start it again when the script is finished.
 mysql_slave=false
+# Set to true if you are backing up from an RDS read replica so we use a different
+# method to stop and start replication. (e.g. CALL mysql.rds_stop_replication;)
+mysql_using_rds=false
 # Use default MySQL config file.
 mysql_use_defaults_file=true
 # Specifically set the defaults file location, e.g. "/etc/my.cnf".
@@ -105,7 +108,11 @@ function cleanup {
   if [ "$mysql_slave" == "true" ]; then
      printf "Restart slave ... "
      if [ "$mysql_slave_restart" == "true" ]; then
-       "$mysqladmin_cmd" ${mysql_args} start-slave >/dev/null
+       if [ "$mysql_using_rds" == true ]; then
+         "$mysql_cmd" ${mysql_args} -e "CALL mysql.rds_start_replication;"
+       else
+         "$mysqladmin_cmd" ${mysql_args} start-slave >/dev/null
+       fi
        success_or_error
      else
        message "warn" "Skipped"
@@ -254,7 +261,11 @@ if [ "$mysql_slave" == "true" ]; then
   slave_sql=$(echo "$slave_mysql" | grep 'Slave_SQL_Running:' | awk '{print $2}')
   printf "Stop slave ... "
   if [ "Yes" == "$slave_io" ] || [ "Yes" == "$slave_sql" ]; then
-    "$mysqladmin_cmd" ${mysql_args} stop-slave >/dev/null
+    if [ "$mysql_using_rds" == true ]; then
+      "$mysql_cmd" ${mysql_args} -e "CALL mysql.rds_stop_replication;"
+    else
+      "$mysqladmin_cmd" ${mysql_args} stop-slave >/dev/null
+    fi
     success_or_error
     mysql_slave_restart=true
   else


### PR DESCRIPTION
This pull request makes the backup script's replicating pausing logic compatible with RDS.

Instead of using...

STOP SLAVE
START SLAVE

It uses...

CALL mysql.rds_stop_replication;
CALL mysql.rds_start_replication;

As per the instructions here: 
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_MySQL.Replication.ReadReplicas.html#USER_MySQL.Replication.ReadReplicas.StartStop