### PR TITLE
feat: allow passing arguments to the aws cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Customisations to the backup script itself (values use bash syntax).
   Default AWS S3 bucket name.
 * `aws_dir: "$timestamp"`
   Default AWS directory to store backups.
+* `aws_extra_arguments: "--endpoint https://s3-compatable-endpoint.example.com"`
+  Extra arguments to pass to the aws cli.
 * `aws_enabled: "true"`
   Enable upload to Amazon S3, if false the "backup_dir_remove" flag will be set to false.
 * `aws_profile: "mysql-s3-backup"`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,7 @@ mysql_backup_config: []
 #  aws_bucket: "mysql-s3-backup"
 #  aws_dir: "$timestamp"
 #  aws_enabled: "true"
+#  aws_extra_arguments: ""
 #  aws_profile: "default"
 #  timestamp: "$(date +"%Y-%m-%d_%H%M")"
 #  backup_dir: "/tmp/mysql-s3-backups/${timestamp}"

--- a/files/backup.sh
+++ b/files/backup.sh
@@ -75,6 +75,8 @@ aws_profile="mysql-s3-backup"
 aws_bucket="mysql-s3-backups"
 # Default AWS directory to store backups.
 aws_dir="$timestamp"
+# Default extra parameters to pass to aws cli tool
+aws_extra_arguments=""
 
 # Load overrides from external config file.
 if [ -f "$config_file" ]; then
@@ -206,7 +208,7 @@ if [ ! -d "$backup_dir" ]; then
 fi
 
 # Build AWS cli options (profile).
-aws_args="--profile $aws_profile"
+aws_args="--profile $aws_profile $aws_extra_arguments"
 # Ensure the S3 bucket exists and we have access to it, or attempt to create.
 # If AWS is disabled, we force set the backup directory removal flag to false.
 if [ "$aws_enabled" == "true" ]; then


### PR DESCRIPTION
Adds the ability for extra arguments to be passed to the aws cli.

I needed this in order to point to a compatible s3 endpoint, but can be used to specify any other type of extra arguments